### PR TITLE
Continue parsing stream even if PES is not found

### DIFF
--- a/src/readPESPackets.js
+++ b/src/readPESPackets.js
@@ -29,7 +29,9 @@ function readPESPackets(filter) {
         if (x.payloadUnitStartIndicator === true) {
           if (x.payload.readUIntBE(0, 3) !== 1) {
             console.error('Expected PES packet at payload start indicator.');
-            return push(null, x);
+            push(null, x);
+            next();
+            return;
           }
           var pesOptional = x.payload.readUInt16BE(6);
           var pesPacket = {


### PR DESCRIPTION
If you're parsing a TS stream, you do not want the parsing to stop the first time a non-PEs packet is encountered

This does exactly that.

Doesn't seem like intended behavior