### PR TITLE
fix: crash due to race condition reading PMTs

### DIFF
--- a/src/readPMTs.js
+++ b/src/readPMTs.js
@@ -19,15 +19,38 @@ const util = require('./util.js');
 
 function genny () {
   var push = null;
-  var next = null;
-  var fn = (hpush, hnext) => {
+  var queue = [];
+  var ended = false;
+
+  var fn = hpush => {
     push = hpush;
-    next = hnext;
+
+    if (queue.length > 0) {
+      while (queue.length > 0) {
+        var item = queue.shift();
+        push(null, item);
+      }
+    }
+
+    if (ended) {
+      push(null, H.nil);
+    }
   };
+  
   return {
     stream : H(fn),
-    push : x => { push(null, x); next(); },
-    end : () => { push(null, H.nil); }
+    push : x => {
+      if (push) { 
+        push(null, x);
+      } else {
+        queue.push(x);
+      }
+    },
+    end : () => { 
+      ended = true;
+      if (push)
+        push(null, H.nil); 
+    }
   };
 }
 


### PR DESCRIPTION
This should fix issue #3.

I'm guessing at some point highland set up generators synchronously, but that doesn't appear to be the case now. What's really needed is to ensure that the ability to push into the new substream is made available synchronously. At first I thought of using Node's `PassThrough` stream to accomplish this, but that would unnecessarily preclude using Tesladon in the browser (which should totally be possible). Instead, I added basic queuing functionality to genny() so that the stream will pick up the pushed items as soon as Highland is able to hook it up.

An alternative fix would be to simply drop the stream items until Highland hooks it up, but in my initial testing this caused a crash. With the PR'ed fix Tesladon happily parses my sample TS file without any errors.